### PR TITLE
Update Bindable.swift

### DIFF
--- a/Sources/Bindable.swift
+++ b/Sources/Bindable.swift
@@ -47,7 +47,7 @@ extension Bindable where Self: NSObject {
         binder = observable
     }
     
-    func valueChanged() {
+    public func valueChanged() {
         if binder.value != self.observingValue() {
             setBinderValue(with: self.observingValue())
         }


### PR DESCRIPTION
Func valueChanged should be declared as public, as it is not accessible from other controllers, but it is important for making extensions and custom classes.